### PR TITLE
Lifecycle stages

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,4 @@
+ROOT_DIR := $(dir "$(realpath $(lastword $(MAKEFILE_LIST)))")
 TF_ACC_EXTERNAL_TIMEOUT_TEST ?= 0
 
 ifeq ($(TF_ACC_EXTERNAL_TIMEOUT_TEST),0)
@@ -29,5 +30,8 @@ test:
 
 testacc:
 	TF_ACC=1 go test -v -cover -timeout $(GO_TIMEOUT) ./...
+
+testbash:
+	TF_ACC_BASH=1 TF_ACC_BASH_LOGFILE="/tmp/resource_external.bash.log" go test -v -cover -timeout=$(GO_TIMEOUT) -parallel=4 ./...
 
 .PHONY: build install lint generate fmt test testacc

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ version it implements, and Terraform:
 
 | Toolbox Provider | Terraform Plugin Protocol | Terraform |   Golang  |
 |:-----------------:|:-------------------------:|:---------:|:---------:|
-|    `>= 0.1.4`     |            `6`            | `>= 1.3.6`| `>= 1.20` |
+|    `>= 0.2.0`     |            `6`            | `>= 1.3.6`| `>= 1.20` |
 
 ## Requirements
 

--- a/examples/resources/external/inline_bash/main.tf
+++ b/examples/resources/external/inline_bash/main.tf
@@ -12,6 +12,33 @@ locals {
   mixed = {"mapped": local.mapped, "listed": local.listed}
 }
 
+resource "toolbox_external" "basic" {
+  create = true
+  read = false
+  update = false
+  delete = false
+  // Recreate is used to force a destroy - create cycle
+  recreate = {
+    one = "two"
+  }
+  query = {
+    one = "two"
+  }
+  program = [
+    "bash",
+    "-c",
+    <<EOF
+      # query is passed to stdin as a JSON object and
+      # will contain the reserved keys "stage" and "old_result"
+      read input
+
+      # Return a json object to be stored in the result attribute
+      # "old_result" is not allowed to prevent duplicate old_result when passed back into query
+      printf '{"one":"two"}'
+    EOF
+  ]
+}
+
 resource "toolbox_external" "mapped" {
   program = [
     "bash",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -16,7 +16,7 @@ func protoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, err
 func providerVersion() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"toolbox": {
-			VersionConstraint: "0.1.4",
+			VersionConstraint: "0.2.0",
 			Source:            "EnterpriseDB/toolbox",
 		},
 	}

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -526,6 +526,13 @@ If the error is unclear, the output can be viewed by enabling Terraform's loggin
 	// Handle non-string values as stringified json
 	convertedResult := map[string]string{}
 	for key, value := range result {
+		if key == "old_result" {
+			diag.AddAttributeError(path.Root("result"),
+				"Reserved Result Key",
+				fmt.Sprintf("The resource was configured with a reserved result key that can cause nested duplicates: %s\nresult: %s\n", key, result),
+			)
+			return emptyMap, diag
+		}
 		switch value.(type) {
 		case string:
 			convertedResult[key] = value.(string)

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -61,7 +61,7 @@ func (e *externalResource) Schema(ctx context.Context, req resource.SchemaReques
 			"systems.\n" +
 			"\n" +
 			"**Warning** Terraform Enterprise does not guarantee availability of any particular language runtimes " +
-			"or external programs beyond standard shell utilities, so it is not recommended to use this data source " +
+			"or external programs beyond standard shell utilities, so it is not recommended to use this resource " +
 			"within configurations that are applied within Terraform Enterprise.",
 
 		Attributes: map[string]schema.Attribute{
@@ -246,7 +246,7 @@ func run_external(ctx context.Context, program []types.String, query map[string]
 	if len(filteredProgram) == 0 {
 		diag.AddAttributeError(path.Root("program"),
 			"External Program Missing",
-			"The data source was configured without a program to execute. Verify the configuration contains at least one non-empty value.",
+			"The resource was configured without a program to execute. Verify the configuration contains at least one non-empty value.",
 		)
 		return emptyMap, diag
 	}
@@ -261,7 +261,7 @@ func run_external(ctx context.Context, program []types.String, query map[string]
 		diag.AddAttributeError(
 			path.Root("query"),
 			"Query Handling Failed",
-			"The data source received an unexpected error while attempting to parse the query. "+
+			"The resource received an unexpected error while attempting to parse the query. "+
 				"This is always a bug in the external provider code and should be reported to the provider developers."+
 				fmt.Sprintf("\n\nError: %s", err),
 		)
@@ -276,8 +276,8 @@ func run_external(ctx context.Context, program []types.String, query map[string]
 		diag.AddAttributeError(
 			path.Root("program"),
 			"External Program Lookup Failed",
-			"The data source received an unexpected error while attempting to parse the query. "+
-				`The data source received an unexpected error while attempting to find the program.
+			"The resource received an unexpected error while attempting to parse the query. "+
+				`The resource received an unexpected error while attempting to find the program.
 
 The program must be accessible according to the platform where Terraform is running.
 
@@ -310,7 +310,7 @@ The program must also be executable according to the platform where Terraform is
 				diag.AddAttributeError(
 					path.Root("program"),
 					"External Program Execution Failed",
-					"The data source received an unexpected error while attempting to execute the program."+
+					"The resource received an unexpected error while attempting to execute the program."+
 						fmt.Sprintf("\n\nProgram: %s", cmd.Path)+
 						fmt.Sprintf("\nError Message: %s", string(exitErr.Stderr))+
 						fmt.Sprintf("\nState: %s", err),
@@ -321,7 +321,7 @@ The program must also be executable according to the platform where Terraform is
 			diag.AddAttributeError(
 				path.Root("program"),
 				"External Program Execution Failed",
-				"The data source received an unexpected error while attempting to execute the program.\n\n"+
+				"The resource received an unexpected error while attempting to execute the program.\n\n"+
 					"The program was executed, however it returned no additional error messaging."+
 					fmt.Sprintf("\n\nProgram: %s", cmd.Path)+
 					fmt.Sprintf("\nState: %s", err),
@@ -332,7 +332,7 @@ The program must also be executable according to the platform where Terraform is
 		diag.AddAttributeError(
 			path.Root("program"),
 			"External Program Execution Failed",
-			"The data source received an unexpected error while attempting to execute the program."+
+			"The resource received an unexpected error while attempting to execute the program."+
 				fmt.Sprintf("\n\nProgram: %s", cmd.Path)+
 				fmt.Sprintf("\nError: %s", err),
 		)
@@ -345,7 +345,7 @@ The program must also be executable according to the platform where Terraform is
 		diag.AddAttributeError(
 			path.Root("program"),
 			"Unexpected External Program Results",
-			`The data source received unexpected results after executing the program.
+			`The resource received unexpected results after executing the program.
 
 Program output must be a JSON encoded map of string keys and string values.
 

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -220,6 +220,45 @@ func TestResource_Query_NullAndEmptyValue(t *testing.T) {
 	})
 }
 
+/*
+Each resources "query" will have a "stage" attribute that will be set to one of the following values:
+- create
+- read
+- update
+- destroy
+*/
+func TestResource_Query_Stage(t *testing.T) {
+	programPath, err := buildResourceTestProgram()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "toolbox_external" "test" {
+						create = true
+						destroy = false
+						update = false
+						read = false
+						program = [%[1]q]
+				
+						query = {
+							value = null,
+							value2 = ""
+						}
+					}
+				`, programPath),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("toolbox_external.test", "result.stage", "create"),
+				),
+			},
+		},
+	})
+}
+
 func TestResource_upgrade(t *testing.T) {
 	programPath, err := buildResourceTestProgram()
 	if err != nil {

--- a/internal/provider/test-programs/tf-acc-external-resource/main.go
+++ b/internal/provider/test-programs/tf-acc-external-resource/main.go
@@ -20,18 +20,18 @@ func main() {
 		panic(err)
 	}
 
-	var query map[string]string
+	query := map[string]any{}
 	err = json.Unmarshal(queryBytes, &query)
 	if err != nil {
 		panic(err)
 	}
 
-	if query["fail"] != "" {
+	if query["fail"] == "true" {
 		fmt.Fprintf(os.Stderr, "I was asked to fail\n")
 		os.Exit(1)
 	}
 
-	var result = map[string]string{
+	var result = map[string]any{
 		"result":      "yes",
 		"query_value": query["value"],
 	}
@@ -41,6 +41,9 @@ func main() {
 	}
 
 	for queryKey, queryValue := range query {
+		if queryKey == "old_result" {
+			continue
+		}
 		result[queryKey] = queryValue
 	}
 


### PR DESCRIPTION
* Expose additional lifecycle stages
  * `read`
  * `update`
* Append `query` input to contain a `stage` key so that the external program is aware of the current lifecycle being used as well as `old_result` key to see the result from the past state.
* `recreate` can be used to force a `destroy - create` lifecycle